### PR TITLE
Use an intermediate script to build and publish.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN chown -R azure:azure /usr/src/page /var/www/
 VOLUME /var/www/
 USER azure
 
-ENTRYPOINT ["jekyll", "build", "--destination", "/var/www"]
+ENTRYPOINT ["_script/build"]

--- a/_script/build
+++ b/_script/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Wrap the entire (production) build and CDN publish process.
+
+set -euo pipefail
+
+ROOT=$(cd $(dirname $0)/..; pwd)
+
+bundle exec jekyll build --destination /var/www
+
+${ROOT}/_script/cdn


### PR DESCRIPTION
This will keep the Ansible playbook nice and clean.
